### PR TITLE
removed hardcoded configs from hared.go, now fully supports .ini config

### DIFF
--- a/hared/contrib/README.md
+++ b/hared/contrib/README.md
@@ -1,5 +1,9 @@
-`hared.go`: Golang version of reference python implementation. mqtt broker address and topic are currently hardcoded
+`hared.go`: Golang version of reference python implementation. 
 
-* prerequisite: `go get github.com/eclipse/paho.mqtt.golang`
+* prerequisites:
+```
+   go get github.com/eclipse/paho.mqtt.golang
+   go get go get gopkg.in/gcfg.v1
+```
 * run as: `go run hared.go`
 * build a binary with: `go build hared.go`

--- a/hared/contrib/hared.go
+++ b/hared/contrib/hared.go
@@ -3,14 +3,51 @@ package main
 // Author: Giovanni Angoli <juzam76@gmail.com>
 
 import (
+    "os"
     "fmt"
     "net"
+    "strconv"
     "encoding/json"
+    "gopkg.in/gcfg.v1"
     "github.com/eclipse/paho.mqtt.golang"
 )
 
 func main() {
-    ServerAddr, _ := net.ResolveUDPAddr("udp",":8035")
+
+    cfg := struct {
+        Defaults struct {
+            Verbose    bool
+            Listenhost string
+            Listenport int
+            Mqtthost   string
+            Mqttport   int
+            Topic      string
+        }
+    }{}
+
+    cfg.Defaults.Verbose    = false
+    cfg.Defaults.Listenhost = "0.0.0.0"
+    cfg.Defaults.Listenport = 8035
+    cfg.Defaults.Mqtthost   = "localhost"
+    cfg.Defaults.Mqttport   = 1883
+    cfg.Defaults.Topic      = "logging/hare"
+
+    cfgfile := "/usr/local/etc/hared.ini"
+
+    if value, ok := os.LookupEnv("HARED_INI"); ok {
+        cfgfile = value
+    }
+
+    error := gcfg.ReadFileInto(&cfg, cfgfile)
+    if error != nil {
+        //fmt.Println(error)
+    }
+
+    if cfg.Defaults.Verbose {
+        fmt.Println(cfg)
+    }
+
+    ServerAddr, _ := net.ResolveUDPAddr("udp", cfg.Defaults.Listenhost + ":" + strconv.Itoa(cfg.Defaults.Listenport))
     ServerConn, _ := net.ListenUDP("udp", ServerAddr)
     defer ServerConn.Close()
 
@@ -19,22 +56,24 @@ func main() {
     for {
         n,_,_ := ServerConn.ReadFromUDP(buf)
 
-        message := string(buf[0:n]);
+        message := string(buf[0:n])
 
-        fmt.Println(message);
+        if cfg.Defaults.Verbose {
+           fmt.Println(message)
+        }
 
         var data map[string]interface{}
         if  error := json.Unmarshal([]byte(message), &data); error != nil {
             continue
         }
 
-        opts := mqtt.NewClientOptions().AddBroker("tcp://192.168.1.130:1883")
+        opts := mqtt.NewClientOptions().AddBroker("tcp://" + cfg.Defaults.Mqtthost + ":" + strconv.Itoa(cfg.Defaults.Mqttport))
 
         c := mqtt.NewClient(opts)
         if token := c.Connect(); token.Wait() && token.Error() != nil {
                     fmt.Println(token.Error())
         }
-        if token := c.Publish("logging/hare", 0, false, message); token.Wait() && token.Error() != nil {
+        if token := c.Publish(cfg.Defaults.Topic, 0, false, message); token.Wait() && token.Error() != nil {
                     fmt.Println(token.Error())
         }
     }


### PR DESCRIPTION
hared.go now suppords hared .ini style config and supports specifying the location of the config file via os variable `$HARED_INI`.

addresses https://github.com/jpmens/hared-hare/issues/9

@jpmens correct me if I'm wrong, there are two things I've noticed, one is that there's no mention of `topic` config in the ini example, another one is that I couldn't find the bit of python code that handles the Env variable is it really there and I'm just code blind?
