### PR TITLE
Go: moved cfgfile read and error handling outside of check for Env variable

### DIFF
--- a/hared/contrib/hared.go
+++ b/hared/contrib/hared.go
@@ -36,11 +36,11 @@ func main() {
 
     if value, ok := os.LookupEnv("HARED_INI"); ok {
         cfgfile = value
+    }
 
-        error := gcfg.ReadFileInto(&cfg, cfgfile)
-        if error != nil {
-            fmt.Println(error)
-        }
+    error := gcfg.ReadFileInto(&cfg, cfgfile)
+    if error != nil {
+        fmt.Println(error)
     }
 
     if cfg.Defaults.Verbose {


### PR DESCRIPTION
Otherwise the config file is read only if its location is specified via Env variable, bypassing the config file in the default '/usr/local/etc/hared.ini' location.