### PR TITLE
mqttwarn.ini s/device/rhost/

### DIFF
--- a/mqttwarn/mqttwarn.ini
+++ b/mqttwarn/mqttwarn.ini
@@ -39,4 +39,4 @@ targets = {
 targets = pushover:pam, log:info, file:mylog, smtp:admins
 alldata = moredata()
 title: SSH login on {hostname}
-format = login via {service} by {user} on {hostname} from {device} at {tstamp}
+format = login via {service} by {user} on {hostname} from {rhost} at {tstamp}


### PR DESCRIPTION
the example `moredata()` function only adds `tstamp` formatted field, so `{device}`  in format expression should read as `{rhost}`.

tested with `make test` and then with this json: `{"tst":1522360765,"hostname":"pitop","user":"jjolie","service":"sshd","rhost":"this.host","tty":null}`

