### PR TITLE
hared.go explicit client disconnection after publish

### DIFF
--- a/hared/contrib/hared.go
+++ b/hared/contrib/hared.go
@@ -83,5 +83,6 @@ func main() {
         if token := c.Publish(cfg.Defaults.Topic, 0, false, message); token.Wait() && token.Error() != nil {
                     fmt.Println(token.Error())
         }
+        c.Disconnect(250)
     }
 }


### PR DESCRIPTION
added `c.Disconnect(250)` that went missing until now. hopefully last PR, prior to TLS implementation