### PR TITLE
Hared.go mqttCAfile handling

### DIFF
--- a/hared/contrib/hared.go
+++ b/hared/contrib/hared.go
@@ -90,6 +90,7 @@ func main() {
         c := mqtt.NewClient(opts)
         if token := c.Connect(); token.Wait() && token.Error() != nil {
                     fmt.Println(token.Error())
+                    continue
         }
         if token := c.Publish(cfg.Defaults.MqttTopic, cfg.Defaults.MqttQos, false, message); token.Wait() && token.Error() != nil {
                     fmt.Println(token.Error())

--- a/hared/contrib/hared.go
+++ b/hared/contrib/hared.go
@@ -7,6 +7,9 @@ import (
     "fmt"
     "net"
     "strconv"
+    "io/ioutil"
+    "crypto/tls"
+    "crypto/x509"
     "encoding/json"
     "gopkg.in/gcfg.v1"
     "github.com/eclipse/paho.mqtt.golang"
@@ -75,6 +78,13 @@ func main() {
         if len(cfg.Defaults.MqttUser) > 0 && len(cfg.Defaults.MqttPass) > 0 {
             opts.SetUsername(cfg.Defaults.MqttUser)
             opts.SetPassword(cfg.Defaults.MqttPass)
+        }
+
+        if len(cfg.Defaults.MqttCAfile) > 0 {
+            CA_Pool := x509.NewCertPool()
+            severCert, _ := ioutil.ReadFile(cfg.Defaults.MqttCAfile)
+            CA_Pool.AppendCertsFromPEM(severCert)
+            opts.SetTLSConfig(&tls.Config{RootCAs: CA_Pool})
         }
 
         c := mqtt.NewClient(opts)


### PR DESCRIPTION
plus a little "fix", skip a loop if an mqtt connection error occurs.

with previouse merge of new ini format, this should address TLS for hared.go

no plans so far to support client side certificates.

addresses https://github.com/jpmens/hared-hare/issues/15