### PR TITLE
fix CC invocation with environment CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-CFLAGS=-Wall -Werror
-
 all: hare
 
 hare: hare.c json.o
-	$(CC) $(CFLAGS) -o hare hare.c json.o $(LDFLAGS)
+	$(CC) -Wall -Werror $(CFLAGS) -o hare hare.c json.o $(LDFLAGS)
 
 json.o: json.c json.h
 


### PR DESCRIPTION
This ensures that any user-provided CFLAGS overrides '-Wall -Werror' and doesn't get replaced by the hardcoded one.

This fix came from FreeBSD where the build was broken when enabling '-fPIE -fPIC'.